### PR TITLE
Fixes for IDA 7.6

### DIFF
--- a/functioninliner.py
+++ b/functioninliner.py
@@ -1222,7 +1222,7 @@ def fix_function_noret_flags():
 
     def remove_noret_typeinfo(func):
         tif = idaapi.tinfo_t()
-        if idaapi.get_tinfo2(func.ea, tif):
+        if idaapi.get_tinfo(tif, func.ea):
             tif_s = idaapi.print_tinfo("", 0, 0, idaapi.PRTYPE_1LINE, tif, func.name, "")
             if "__noreturn" in tif_s:
                 tif_s = tif_s.replace("__noreturn", "")
@@ -2386,12 +2386,18 @@ class FunctionInlinerHooks(idaapi.UI_Hooks):
         for action in self.menu_actions:
             idaapi.attach_action_to_menu(action.path, action.name, idaapi.SETMENU_APP)
 
-    def finish_populating_tform_popup(self, form, popup):
-        if idaapi.get_tform_type(form) in (idaapi.BWN_DISASM, idaapi.BWN_PSEUDOCODE):
-            idaapi.attach_action_to_popup(form, popup, "-", None, idaapi.SETMENU_FIRST)
-            for action in reversed(self.ctx_actions):
-                idaapi.attach_action_to_popup(form, popup, action.name, None, idaapi.SETMENU_FIRST)
-
+    if idaapi.IDA_SDK_VERSION >= 700:
+        def finish_populating_widget_popup(self, form, popup):
+            if idaapi.get_widget_type(form) in (idaapi.BWN_DISASM, idaapi.BWN_PSEUDOCODE):
+                idaapi.attach_action_to_popup(form, popup, "-", None, idaapi.SETMENU_FIRST)
+                for action in reversed(self.ctx_actions):
+                    idaapi.attach_action_to_popup(form, popup, action.name, None, idaapi.SETMENU_FIRST)
+    else:
+        def finish_populating_tform_popup(self, form, popup):
+            if idaapi.get_tform_type(form) in (idaapi.BWN_DISASM, idaapi.BWN_PSEUDOCODE):
+                idaapi.attach_action_to_popup(form, popup, "-", None, idaapi.SETMENU_FIRST)
+                for action in reversed(self.ctx_actions):
+                    idaapi.attach_action_to_popup(form, popup, action.name, None, idaapi.SETMENU_FIRST)
 
 class FunctionInlinerPlugin(idaapi.plugin_t):
     version = idaapi.IDP_INTERFACE_VERSION


### PR DESCRIPTION
This PR fixes some issue with IDA 7.6
- idaapi.get_tinfo2 not defined
- Context menus not working

I'm not sure if my `get_tinfo2` fix compatible to older IDA versions, but apparently only `get_tinfo` is exported from `ida_nalt` to `idaapi`, and `get_tinfo2` is defined as `get_tinfo`, but with type checks on argument to ensure the correct prototype.